### PR TITLE
Forward calls and allow drivers to implement their own specific methods

### DIFF
--- a/src/Driver/MetaTagDriver.php
+++ b/src/Driver/MetaTagDriver.php
@@ -25,4 +25,19 @@ class MetaTagDriver extends AbstractDriver
 
         return $this;
     }
+
+    /**
+     * @param string|string[] $keywords
+     */
+    public function keywords($keywords): MetaTagDriver
+    {
+        $this->tags['keywords'] = new MetaTag([
+            'attributes' => [
+                'name' => 'keywords',
+                'content' => is_array($keywords) ? implode(', ', $keywords) : $keywords,
+            ],
+        ]);
+
+        return $this;
+    }
 }

--- a/src/Exception/InvalidDriverMethodException.php
+++ b/src/Exception/InvalidDriverMethodException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FriendsOfInertia\LaravelSEO\Exception;
+
+class InvalidDriverMethodException extends \Exception
+{
+}

--- a/src/SEO.php
+++ b/src/SEO.php
@@ -88,7 +88,7 @@ class SEO
         $forwarded = false;
 
         foreach ($this->drivers() as $driver) {
-            $forwarded = $forwarded | $this->forwardCallTo($driver, $method, $arguments);
+            $forwarded = $forwarded || $this->forwardCallTo($driver, $method, $arguments);
         }
 
         if (! $forwarded) {

--- a/tests/SEOTest.php
+++ b/tests/SEOTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use FriendsOfInertia\LaravelSEO\Driver\MetaTagDriver;
 use FriendsOfInertia\LaravelSEO\Driver\OpenGraphDriver;
 use FriendsOfInertia\LaravelSEO\Exception\InvalidDriverException;
+use FriendsOfInertia\LaravelSEO\Exception\InvalidDriverMethodException;
 use FriendsOfInertia\LaravelSEO\SEO;
 use PHPUnit\Framework\TestCase;
 use TypeError;
@@ -62,5 +63,49 @@ class SEOTest extends TestCase
 
             $this->assertCount(1, $driver->getTags());
         }
+    }
+
+    public function test_it_does_not_pass_unknown_onto_drivers()
+    {
+        $this->expectException(InvalidDriverMethodException::class);
+
+        $seo = new SEO;
+        $seo->registerDriver('openGraph', new OpenGraphDriver);
+        $seo->registerDriver('meta', new MetaTagDriver);
+
+        $seo->unknown('Test');
+    }
+
+    public function test_it_forwards_keywords_to_meta_tag_driver()
+    {
+        $seo = new SEO;
+        $seo->registerDriver('openGraph', new OpenGraphDriver);
+        $seo->registerDriver('meta', new MetaTagDriver);
+
+        $seo->keywords(['InertiaJS', 'PHP', 'Laravel']);
+
+        $openGraphDriver = $seo->driver('openGraph');
+        $this->assertCount(0, $openGraphDriver->getTags());
+
+        $metaDriver = $seo->driver('meta');
+        $this->assertCount(1, $metaDriver->getTags());
+        $this->assertTrue($metaDriver->getTags()->has('keywords'));
+        $this->assertSame([
+            'name' => 'keywords',
+            'content' => 'InertiaJS, PHP, Laravel',
+        ], $metaDriver->getTags()->get('keywords')->attributes);
+    }
+
+    public function test_it_can_return_the_driver_through_magic_method()
+    {
+        $seo = new SEO;
+        $seo->registerDriver('openGraph', new OpenGraphDriver);
+        $seo->registerDriver('meta', new MetaTagDriver);
+
+        $openGraphDriver = $seo->openGraphDriver();
+        $this->assertInstanceOf(OpenGraphDriver::class, $openGraphDriver);
+
+        $metaDriver = $seo->metaDriver();
+        $this->assertInstanceOf(MetaTagDriver::class, $metaDriver);
     }
 }


### PR DESCRIPTION
This PR introduces two features, both make use of `__call`

Drivers can be fetched using their name, like `$seo->openGraphDriver()` and `$seo->metaDriver()`

Furthermore, all calls to SEO are forwarded to the drivers. If that method doesn't exist on any of the drivers an exception is thrown. This allows for drivers to have their own specific methods that don't have to be implemented in SEO, for example `$seo->keywords('InertiaJS, Laravel, PHP')` instead of the need to call `$seo->metaDriver()->keywords('InertiaJS, Laravel, PHP') / $seo->driver('meta')->keywords('InertiaJS, Laravel, PHP')`